### PR TITLE
v-1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the "avila-tek-extensions" extension pack will be documen
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.1.0] - 2021-02-09
+
+### Added
+
+- Replace `vscode-todo-highlight` with `todo-tree` because is actively maintain
+- Added `github.vscode-pull-request-github` to improve our new GitHub workflow
+
+### Removed
+
+- Remove de following extensions: `html-snippets`, `npm-intellisense`, `path-intellisense`, `vscode-import-cost`, `vscode-todo-highlight` [issues here](https://medium.com/swlh/the-vs-code-extensions-that-you-might-not-need-42164e491567)
+- Remove `vscode-versionlens` because is easier to use `npm-check-updates` and slow init time
+
 ## [1.0.1] - 2020-09-30
 
 - Fix readme

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "avila-tek-extensions",
   "displayName": "Avila Tek Extension Pack",
   "description": "A group of extensions used in Avila Tek",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "icon": "logo-1.png",
   "publisher": "avilatek",
   "galleryBanner": {
@@ -34,9 +34,7 @@
   },
   "extensionPack": [
     "aaron-bond.better-comments",
-    "abusaidm.html-snippets",
     "bradlc.vscode-tailwindcss",
-    "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense",
     "CoenraadS.bracket-pair-colorizer-2",
     "dbaeumer.vscode-eslint",
@@ -47,21 +45,20 @@
     "esbenp.prettier-vscode",
     "formulahendry.auto-close-tag",
     "formulahendry.auto-rename-tag",
+    "github.vscode-pull-request-github",
     "GraphQL.vscode-graphql",
+    "gruntfuggly.todo-tree",
     "mgmcdermott.vscode-language-babel",
     "mikestead.dotenv",
     "ms-azuretools.vscode-docker",
     "ms-vscode.vscode-typescript-next",
     "msjsdiag.debugger-for-chrome",
     "naumovs.color-highlight",
-    "pflannery.vscode-versionlens",
     "PKief.material-icon-theme",
     "ritwickdey.LiveServer",
     "streetsidesoftware.code-spell-checker",
     "streetsidesoftware.code-spell-checker-spanish",
     "VisualStudioExptTeam.vscodeintellicode",
-    "waderyan.gitblame",
-    "wayou.vscode-todo-highlight",
-    "wix.vscode-import-cost"
+    "waderyan.gitblame"
   ]
 }


### PR DESCRIPTION
# What is new?

### Added

- Replace `vscode-todo-highlight` with `todo-tree` because is actively maintain
- Added `github.vscode-pull-request-github` to improve our new GitHub workflow

### Removed

- Remove de following extensions: `html-snippets`, `npm-intellisense`, `path-intellisense`, `vscode-import-cost`, `vscode-todo-highlight` [issues here](https://medium.com/swlh/the-vs-code-extensions-that-you-might-not-need-42164e491567)
- Remove `vscode-versionlens` because is easier to use `npm-check-updates` and slow init time